### PR TITLE
fix: bump Go to 1.26.4 for stdlib security fixes (GO-2026-5037/5038/5039)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/natrontech/openvpn-exporter
 
-go 1.26.3
+go 1.26.4
 
 require github.com/prometheus/client_golang v1.23.2
 


### PR DESCRIPTION
## What

Bump the `go` directive in `go.mod` from `1.26.3` to `1.26.4`.

## Why

Go `1.26.3` stdlib is affected by 3 known vulnerabilities, all fixed in `1.26.4`:

- [GO-2026-5037](https://osv.dev/GO-2026-5037)
- [GO-2026-5038](https://osv.dev/GO-2026-5038)
- [GO-2026-5039](https://osv.dev/GO-2026-5039)

These surfaced as a failing `analyze / osv-scan` (govulncheck) required check. CI uses `go-version-file: go.mod`, so this bump also moves the build toolchain to the patched release. Dependabot does not bump the Go toolchain version, so this needs to be done manually.